### PR TITLE
Long-term fix for PRs from a fork, CODEOWNER file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @praseodym @jschuurk-kr
+*       @praseodym @jschuurk-kr @ring-ring-ring

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @praseodym @jschuurk-kr

--- a/dist/index.js
+++ b/dist/index.js
@@ -29106,7 +29106,7 @@ if (missingAuthors.length > 0) {
 const authors = Array.from(new Set(commits.data
     .filter((commit) => commit.author.type.toLowerCase() !== "bot")
     .map((commit) => commit.author.login))).sort();
-console.log(`authors log: ${authors}`);
+console.log(`authors: ${authors}`);
 const fileContentResponse = await octokit.rest.repos.getContent({
     // "base" so we retrieve the contributors file from the receiving repo,
     // not from the submitting one, which can be a fork we don't own

--- a/dist/index.js
+++ b/dist/index.js
@@ -29094,6 +29094,8 @@ if (!_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request) 
     throw new Error("No pull request context available");
 }
 const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit)(githubToken);
+(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`owner from context: ${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.owner}`);
+(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`repo from context: ${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.repo}`);
 const commits = await octokit.rest.pulls.listCommits({
     owner: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.owner,
     repo: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.repo,
@@ -29106,16 +29108,18 @@ if (missingAuthors.length > 0) {
 const authors = Array.from(new Set(commits.data
     .filter((commit) => commit.author.type.toLowerCase() !== "bot")
     .map((commit) => commit.author.login))).sort();
+(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`authors: ${authors}`);
 const fileContentResponse = await octokit.rest.repos.getContent({
     // TODO: Get owner and repo from context, but make sure it's the receiving
     // owner and repo. So not context.payload.pull_request["head"]["repo"],
     // which in case of a PR from a fork, is the forked repo, not our repo.
-    owner: "kiesraad",
-    repo: "abacus",
+    owner: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.base.repo.owner.login,
+    repo: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.base.repo.name,
     path: contributorsFile,
     ref: "refs/heads/main",
 });
 const contributors = (js_yaml__WEBPACK_IMPORTED_MODULE_2__/* ["default"].load */ .ZP.load(Buffer.from(fileContentResponse.data.content, "base64").toString()) ?? []);
+(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`contributors: ${contributors}`);
 const missing = authors.filter((author) => contributors.includes(author) === false);
 if (missing.length > 0) {
     console.log(`Not all contributors have signed the CLA. Missing: ${missing.join(", ")}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29106,7 +29106,6 @@ if (missingAuthors.length > 0) {
 const authors = Array.from(new Set(commits.data
     .filter((commit) => commit.author.type.toLowerCase() !== "bot")
     .map((commit) => commit.author.login))).sort();
-(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`authors info: ${authors}`);
 console.log(`authors log: ${authors}`);
 const fileContentResponse = await octokit.rest.repos.getContent({
     // "base" so we retrieve the contributors file from the receiving repo,
@@ -29117,7 +29116,7 @@ const fileContentResponse = await octokit.rest.repos.getContent({
     ref: "refs/heads/main",
 });
 const contributors = (js_yaml__WEBPACK_IMPORTED_MODULE_2__/* ["default"].load */ .ZP.load(Buffer.from(fileContentResponse.data.content, "base64").toString()) ?? []);
-(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`contributors: ${contributors}`);
+console.log(`contributors: ${contributors}`);
 const missing = authors.filter((author) => contributors.includes(author) === false);
 if (missing.length > 0) {
     console.log(`Not all contributors have signed the CLA. Missing: ${missing.join(", ")}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29094,8 +29094,6 @@ if (!_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request) 
     throw new Error("No pull request context available");
 }
 const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit)(githubToken);
-(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`owner from context: ${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.owner}`);
-(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`repo from context: ${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.repo}`);
 const commits = await octokit.rest.pulls.listCommits({
     owner: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.owner,
     repo: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.repo,
@@ -29108,11 +29106,11 @@ if (missingAuthors.length > 0) {
 const authors = Array.from(new Set(commits.data
     .filter((commit) => commit.author.type.toLowerCase() !== "bot")
     .map((commit) => commit.author.login))).sort();
-(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`authors: ${authors}`);
+(0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`authors info: ${authors}`);
+console.log(`authors log: ${authors}`);
 const fileContentResponse = await octokit.rest.repos.getContent({
-    // TODO: Get owner and repo from context, but make sure it's the receiving
-    // owner and repo. So not context.payload.pull_request["head"]["repo"],
-    // which in case of a PR from a fork, is the forked repo, not our repo.
+    // "base" so we retrieve the contributors file from the receiving repo,
+    // not from the submitting one, which can be a fork we don't own
     owner: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.base.repo.owner.login,
     repo: _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload.pull_request.base.repo.name,
     path: contributorsFile,

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
 # CLA Bot
 
 Simple GitHub Actions bot that'll check if the GitHub user that opened a PR is present in the contributors.yml file. If not, it'll post a comment to ask the user to review and sign the CLA
+
+## Making changes
+1. Update the code in `src/index.ts`
+1. Run `npm build`

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const authors = Array.from(
 	)
 ).sort();
 
-console.log(`authors log: ${authors}`)
+console.log(`authors: ${authors}`)
 
 const fileContentResponse = await octokit.rest.repos.getContent({
 	// "base" so we retrieve the contributors file from the receiving repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { info, getInput, setOutput } from "@actions/core";
+import { getInput, setOutput } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 import type { components } from "@octokit/openapi-types";
 import yaml from "js-yaml";
@@ -32,7 +32,6 @@ const authors = Array.from(
 	)
 ).sort();
 
-info(`authors info: ${authors}`)
 console.log(`authors log: ${authors}`)
 
 const fileContentResponse = await octokit.rest.repos.getContent({
@@ -51,7 +50,7 @@ const contributors = (yaml.load(
 	).toString()
 ) ?? []) as string[];
 
-info(`contributors: ${contributors}`)
+console.log(`contributors: ${contributors}`)
 
 const missing = authors.filter(
 	(author) => contributors.includes(author) === false

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getInput, setOutput, info } from "@actions/core";
+import { info, getInput, setOutput } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 import type { components } from "@octokit/openapi-types";
 import yaml from "js-yaml";
@@ -11,9 +11,6 @@ if (!context.payload.pull_request) {
 }
 
 const octokit = getOctokit(githubToken);
-
-info(`owner from context: ${context.repo.owner}`)
-info(`repo from context: ${context.repo.repo}`)
 
 const commits = await octokit.rest.pulls.listCommits({
 	owner: context.repo.owner,
@@ -35,12 +32,12 @@ const authors = Array.from(
 	)
 ).sort();
 
-info(`authors: ${authors}`)
+info(`authors info: ${authors}`)
+console.log(`authors log: ${authors}`)
 
 const fileContentResponse = await octokit.rest.repos.getContent({
-	// TODO: Get owner and repo from context, but make sure it's the receiving
-	// owner and repo. So not context.payload.pull_request["head"]["repo"],
-	// which in case of a PR from a fork, is the forked repo, not our repo.
+	// "base" so we retrieve the contributors file from the receiving repo,
+	// not from the submitting one, which can be a fork we don't own
 	owner: context.payload.pull_request["base"]["repo"]["owner"]["login"],
 	repo: context.payload.pull_request["base"]["repo"]["name"],
 	path: contributorsFile,


### PR DESCRIPTION
relates to https://github.com/kiesraad/abacus/issues/513

Scope:
- fix retrieving contributors file from `"base"` instead of `"head"` (relevant in case of PRs from a fork)
- add a CODEOWNER file
- add reminder to README to run `npm build`

Idea behind the CODEOWNER file is that we give the Abacus dev team access to this repo, but require an approval from at least one of the people in the CODEOWNER file.

---

I tested the fix by adding this branch of cla-bot to a repo with both an internal and external PR: https://github.com/jschuurk-kr/gh-actions-playground/pulls Then I tried different permutations of the existence and the contents of `contributors.yml` in the `main` branch of this repo and the two PR branches.