### PR TITLE
Add configurable repository for contributors file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,18 @@
-name: 'CLA Bot'
-description: 'Check if a contributor has signed the CLA'
+name: "CLA Bot"
+description: "Check if a contributor has signed the CLA"
 inputs:
   github-token:
     description: GitHub Token
     required: true
     default: ${{ github.token }}
+  contributors-repository-owner:
+    description: Owner of the repository containing the contributors file
+  contributors-repository-name:
+    description: Name of the repository containing the contributors file
   contributors-file:
-    description: Contributors File
+    description: Path to the contributors file
     required: true
     default: contributors.yml
 runs:
-  using: 'node20'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,10 @@ inputs:
     default: ${{ github.token }}
   contributors-repository-owner:
     description: Owner of the repository containing the contributors file
+    required: true
   contributors-repository-name:
     description: Name of the repository containing the contributors file
+    required: true
   contributors-file:
     description: Path to the contributors file
     required: true

--- a/license
+++ b/license
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2023 Directus
+Copyright (c) 2024-2025 Kiesraad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
 			}
 		},
 		"node_modules/@actions/http-client": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.1.tgz",
-			"integrity": "sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+			"integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -71,16 +71,16 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-			"integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+			"integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
-				"@octokit/request": "^8.3.1",
-				"@octokit/request-error": "^5.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
 				"@octokit/types": "^13.0.0",
 				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
@@ -90,9 +90,9 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
-			"integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -104,13 +104,13 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
-			"integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^8.3.0",
+				"@octokit/request": "^8.4.1",
 				"@octokit/types": "^13.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -126,9 +126,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
-			"integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -192,14 +192,14 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
-			"integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^9.0.1",
-				"@octokit/request-error": "^5.1.0",
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
 				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -208,9 +208,9 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
-			"integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -223,14 +223,21 @@
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
+				"@octokit/openapi-types": "^24.2.0"
 			}
+		},
+		"node_modules/@octokit/types/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/js-yaml": {
 			"version": "4.0.9",
@@ -328,9 +335,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.28.5",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-			"integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,8 @@ if (!context.payload.pull_request) {
 	throw new Error("No pull request context available");
 }
 
-// "base" so we retrieve the contributors file from the receiving repo,
-// not from the submitting one, which can be a fork we don't own
-const contributorsRepositoryOwner =
-	getInput("contributors-repository-owner") ||
-	context.payload.pull_request["base"]["repo"]["owner"]["login"];
-const contributorsRepositoryName =
-	getInput("contributors-repository-name") ||
-	context.payload.pull_request["base"]["repo"]["name"];
+const contributorsRepositoryOwner = getInput("contributors-repository-owner");
+const contributorsRepositoryName = getInput("contributors-repository-name");
 const contributorsFile = getInput("contributors-file");
 const githubToken = getInput("github-token");
 const octokit = getOctokit(githubToken);


### PR DESCRIPTION
This enables us to use an existing contributors file (e.g. in the Abacus repository) from other repositories (e.g. the new [abacus-documentatie repository](https://github.com/kiesraad/abacus-documentatie)) without having to manage a contributors file for each repository.